### PR TITLE
Don't disable the context right-click' menu

### DIFF
--- a/src/main/webapp/js/esup-stock.js
+++ b/src/main/webapp/js/esup-stock.js
@@ -1645,11 +1645,6 @@ function deleteFiles(dirsDataStruct) {
         console.log("item  context menu");
         return false;
         });
-
-      $("body").bind('contextmenu', function() {
-        console.log("Body  system context menu ");
-        return false;
-        });
   }
 
   function handleItemDblClick(e, jqElem) {


### PR DESCRIPTION
Resolves #47 

### Warning!

I'm not sure this PR is ready.  It seems that esup-filemanager may have implemented its own right-click menu, and disabling the "normal" (browser-supplied) menu might be necessary for it to function.  (I don't know... I haven't tried it... I don't know the esup-filemanager well enough, yer.)

If that's the case, we should instead change the relevant code to something like...

```
$("#someIdAtTheRootOfThePortletMarkup").bind('contextmenu', function() {
    console.log("Body  system context menu ");
    return false;
});
```