### PR TITLE
fix: ExceptionHandling problem

### DIFF
--- a/src/main/java/org/esupportail/portlet/filemanager/portlet/PortletControllerAjax.java
+++ b/src/main/java/org/esupportail/portlet/filemanager/portlet/PortletControllerAjax.java
@@ -542,10 +542,16 @@ public class PortletControllerAjax {
 	}
 
 	
-	@ExceptionHandler
-	public ModelAndView handleException(EsupStockException ex, ResourceRequest resourceRequest, ResourceResponse resourcesResponse, Locale loc) {
+	@ExceptionHandler(Exception.class)
+	public ModelAndView handleException(Exception ex, ResourceRequest resourceRequest, ResourceResponse resourcesResponse, Locale loc) {
+		EsupStockException exn;
+		if (ex instanceof EsupStockException) {
+			 exn = (EsupStockException) ex;
+		} else {
+			exn = new EsupStockException(ex);
+		}
 	    ModelMap modelMap = new ModelMap();
-	    String errorText = messageSource.getMessage(ex.getCodeI18n(), new String[] {ex.getMessage()}, loc);
+	    String errorText = messageSource.getMessage(exn.getCodeI18n(), new String[] {exn.getMessage()}, loc);
 	    modelMap.put("errorText", errorText);
 	    return new ModelAndView("ajax_error", modelMap);
 	}


### PR DESCRIPTION
When an Exception occured (not an EsupStockException) the ExceptionHandling is called and an error occure due to wrong matching argument EsupStockException. This change permit to intercept all errors and to deliver a clean error message.
In my case it was a NPE from jcifs-ng when deleting a file.