### PR TITLE
new version management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,9 @@
 
   <!-- Dependency Version Properties -->
   <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.source>1.6</project.build.source>
+    <project.build.target>1.8</project.build.target>
     <uportal-libs.version>5.1.0</uportal-libs.version>
   </properties>
 
@@ -437,10 +440,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.5.1</version>
-        <configuration>
-          <source>1.6</source>
-          <target>1.8</target>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -560,21 +559,6 @@
           </execution>
         </executions>
       </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <version>2.2.1</version>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>jar-no-fork</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>esup-filemanager</artifactId>
   <packaging>war</packaging>
   <name>esup-filemanager</name>
-  <version>3.2.1-SNAPSHOT</version>
+  <version>4.0.0-SNAPSHOT</version>
 
 
   <description>ESUP File Manager is a JSR286 Portlet. Esup File Manager allows users to perform file management on their HomeDirs.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -438,8 +438,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.5.1</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Due to integration with uP5 with the move to java 1.8 (java 1.7 before) that introduced a BREAKING CHANGE we move to a new version following semVer convention.