### PR TITLE
Clearpass form fallback auth

### DIFF
--- a/src/main/java/org/esupportail/portlet/filemanager/services/FsAccess.java
+++ b/src/main/java/org/esupportail/portlet/filemanager/services/FsAccess.java
@@ -177,8 +177,8 @@ public abstract class FsAccess {
 	}
 
 	public boolean formAuthenticationRequired(SharedUserPortletParameters userParameters) {
-		if(this.userAuthenticatorService instanceof FormUserPasswordAuthenticatorService) {
-			if(this.userAuthenticatorService.getUserPassword(userParameters).getPassword() == null || this.userAuthenticatorService.getUserPassword(userParameters).getPassword().length() == 0) {
+		if(this.userAuthenticatorService.formAuthenticationNeeded(userParameters)) {
+			if(this.userAuthenticatorService.getUserPassword(userParameters) == null || this.userAuthenticatorService.getUserPassword(userParameters).getPassword() == null || this.userAuthenticatorService.getUserPassword(userParameters).getPassword().length() == 0) {
 				this.userAuthenticatorService.initialize(userParameters);
 				return true;
 			}

--- a/src/main/java/org/esupportail/portlet/filemanager/services/auth/FormUserPasswordAuthenticatorService.java
+++ b/src/main/java/org/esupportail/portlet/filemanager/services/auth/FormUserPasswordAuthenticatorService.java
@@ -24,4 +24,8 @@ public class FormUserPasswordAuthenticatorService extends UserPasswordAuthentica
 
 	protected static final Log log = LogFactory.getLog(FormUserPasswordAuthenticatorService.class);
 	
+	public boolean formAuthenticationNeeded() {
+		return true;
+	}
+
 }

--- a/src/main/java/org/esupportail/portlet/filemanager/services/auth/UserAuthenticatorService.java
+++ b/src/main/java/org/esupportail/portlet/filemanager/services/auth/UserAuthenticatorService.java
@@ -26,4 +26,6 @@ public interface UserAuthenticatorService {
 	
 	public abstract UserPassword getUserPassword(SharedUserPortletParameters userParameters);
 
+	public abstract boolean formAuthenticationNeeded(SharedUserPortletParameters userParameters);
+
 }

--- a/src/main/java/org/esupportail/portlet/filemanager/services/auth/UserPasswordAuthenticatorService.java
+++ b/src/main/java/org/esupportail/portlet/filemanager/services/auth/UserPasswordAuthenticatorService.java
@@ -81,5 +81,11 @@ public class UserPasswordAuthenticatorService implements UserAuthenticatorServic
 	public UserPassword getUserPassword(SharedUserPortletParameters userParameters) {
 		return userPassword;
 	}
+	
+	public boolean formAuthenticationNeeded(SharedUserPortletParameters userParameters) {
+		return false;
+	}
 
 }
+
+

--- a/src/main/java/org/esupportail/portlet/filemanager/services/auth/cas/ClearPassUserCasAuthenticatorService.java
+++ b/src/main/java/org/esupportail/portlet/filemanager/services/auth/cas/ClearPassUserCasAuthenticatorService.java
@@ -15,29 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
-Copyright (c) 2009, Mail Portlet Development Team
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
-following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this list of conditions and the following
-  disclaimer.
-* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
-  disclaimer in the documentation and/or other materials provided with the distribution.
-* Neither the name of the Mail Portlet Development Team nor the names of its contributors may be used to endorse or
-  promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
 package org.esupportail.portlet.filemanager.services.auth.cas;
 
 import java.nio.file.Files;
@@ -55,6 +32,7 @@ import org.apache.commons.logging.LogFactory;
 import org.esupportail.portlet.filemanager.beans.SharedUserPortletParameters;
 import org.esupportail.portlet.filemanager.beans.UserPassword;
 import org.esupportail.portlet.filemanager.exceptions.EsupStockException;
+import org.esupportail.portlet.filemanager.services.auth.FormUserPasswordAuthenticatorService;
 import org.esupportail.portlet.filemanager.services.auth.UserAuthenticatorService;
 import org.jasig.cas.client.validation.Assertion;
 
@@ -68,28 +46,37 @@ public class ClearPassUserCasAuthenticatorService implements UserAuthenticatorSe
     protected String credentialAttribute = "credential";
 
     protected PrivateKey privateKey;
-
+    
     private String domain;
-
+    
+    UserPassword userPassword;
+    
+    FormUserPasswordAuthenticatorService formUserPasswordAuthenticatorServiceFallBack;
+    
+    Boolean initialized = false;
+	
     public void setDomain(String domain) {
-        this.domain = domain;
+	this.domain = domain;
     }
-
+    
     public void setUserCasAuthenticatorServiceRoot(UserCasAuthenticatorServiceRoot userCasAuthenticatorServiceRoot) {
-        this.userCasAuthenticatorServiceRoot = userCasAuthenticatorServiceRoot;
+	this.userCasAuthenticatorServiceRoot = userCasAuthenticatorServiceRoot;
     }
-
+    
     public void initialize(SharedUserPortletParameters userParameters) {
-        this.userCasAuthenticatorServiceRoot.initialize(userParameters);
+	if(!initialized) {
+	    this.userCasAuthenticatorServiceRoot.initialize(userParameters);
+	    initialized = true;
+	}
     }
-
+    
     public void setPkcs8Key(String pkcs8Key) throws Exception {
-        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
-        Path pkcs8KeyPath = Paths.get(pkcs8Key);
-        privateKey = keyFactory.generatePrivate(new PKCS8EncodedKeySpec(Files.readAllBytes(pkcs8KeyPath)));
+	KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+	Path pkcs8KeyPath = Paths.get(pkcs8Key);
+	privateKey = keyFactory.generatePrivate(new PKCS8EncodedKeySpec(Files.readAllBytes(pkcs8KeyPath)));
     }
-
-    public UserPassword getUserPassword(SharedUserPortletParameters userParameters) {
+	
+    public UserPassword getClearPassUserPassword(SharedUserPortletParameters userParameters) {
 
         if (log.isDebugEnabled()) {
             log.debug("getting credentials using " + this.getClass().getName());
@@ -130,11 +117,30 @@ public class ClearPassUserCasAuthenticatorService implements UserAuthenticatorSe
     }
 
     protected String decodeCredential(String encodedPsw) throws Exception {
-        Cipher cipher = Cipher.getInstance(privateKey.getAlgorithm());
-        byte[] cred64 = Base64.decodeBase64(encodedPsw.getBytes());
-        cipher.init(Cipher.DECRYPT_MODE, privateKey);
-        byte[] cipherData = cipher.doFinal(cred64);
-        return new String(cipherData);
+	Cipher cipher = Cipher.getInstance(privateKey.getAlgorithm());
+	byte[] cred64 = Base64.decodeBase64(encodedPsw.getBytes());
+	cipher.init(Cipher.DECRYPT_MODE, privateKey);
+	byte[] cipherData = cipher.doFinal(cred64);
+	return new String(cipherData);
+    }
+	
+    public UserPassword getUserPassword(SharedUserPortletParameters userParameters) {
+	if(userPassword == null) {
+	    userPassword = getClearPassUserPassword(userParameters);
+	}
+	if(userPassword == null) {
+	    formUserPasswordAuthenticatorServiceFallBack = new FormUserPasswordAuthenticatorService();
+	    formUserPasswordAuthenticatorServiceFallBack.setDomain(domain);
+	    userPassword = formUserPasswordAuthenticatorServiceFallBack.getUserPassword(userParameters);
+	}
+	return userPassword;
+    }
+	
+
+    public boolean formAuthenticationNeeded(SharedUserPortletParameters userParameters) {
+	initialize(userParameters);
+	getUserPassword(userParameters);
+	return formUserPasswordAuthenticatorServiceFallBack != null;
     }
 
 }

--- a/src/main/java/org/esupportail/portlet/filemanager/services/auth/cas/UserCasAuthenticatorService.java
+++ b/src/main/java/org/esupportail/portlet/filemanager/services/auth/cas/UserCasAuthenticatorService.java
@@ -110,4 +110,8 @@ public class UserCasAuthenticatorService implements UserAuthenticatorService {
 
     }
 
+	public boolean formAuthenticationNeeded(SharedUserPortletParameters userParameters) {
+		return false;
+	}
+
 }

--- a/src/main/webapp/WEB-INF/context/drives.xml
+++ b/src/main/webapp/WEB-INF/context/drives.xml
@@ -230,8 +230,8 @@
       <property name="target" value="sftp://stock-2.mon-univ.fr"/>
   </bean>
 
-  <!-- if you want to use clearPass (CAS V5) use instead this casUserAuthenticationService 
-  <bean name="casUserAuthenticationService" class="org.esupportail.portlet.filemanager.services.auth.cas.ClearPassUserCasAuthenticatorService">
+  <!-- if you want to use clearPass (CAS V5) use instead this casUserAuthenticationService - scope = session is needed because of fallback form auth capabilty of ClearPassUserCasAuthenticatorService
+  <bean name="casUserAuthenticationService" class="org.esupportail.portlet.filemanager.services.auth.cas.ClearPassUserCasAuthenticatorService" scope="session">
       <property name="userCasAuthenticatorServiceRoot" ref="casUserAuthenticationServiceRoot"/>
       <property name="pkcs8Key" value="/etc/cas/config/security/private.p8"/>
       </bean>


### PR DESCRIPTION
The goal here is to have the username/password form displayed to users that can't have the CAS ClearPass OK in esup-filemanager.
Indeed, if you use spnego/kerberos on CAS for some desktops, users didn't send password (don't need it) on CAS and CAS can't send password to esup-filemanager.
With this patch, the username/password form will be displayed as fallback authentication.